### PR TITLE
Support status from ESP Easy

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,6 +162,10 @@ var pollingtoevent = require('polling-to-event');
 		this.log('HTTP get power function failed: %s', error.message);
 		callback(error);
 	} else {
+		// Support Json return value from ESP Easy http://www.esp8266.nu/ 
+		if(responseBody instanceof Object && responseBody.state != undefined) {
+			responseBody = responseBody.state;
+		}
 		var binaryState = parseInt(responseBody);
 		var powerOn = binaryState > 0;
 		this.log("Power state is currently %s", binaryState);

--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ var pollingtoevent = require('polling-to-event');
 	} else {
 		// Support Json return value from ESP Easy http://www.esp8266.nu/ 
 		if(isNaN(parseInt(responseBody))) {
-			responseBody = eval("(" + responseBody + ")");
+			responseBody = JSON.parse(responseBody);
 			responseBody = responseBody.state;
 		}
 		var binaryState = parseInt(responseBody);

--- a/index.js
+++ b/index.js
@@ -163,7 +163,8 @@ var pollingtoevent = require('polling-to-event');
 		callback(error);
 	} else {
 		// Support Json return value from ESP Easy http://www.esp8266.nu/ 
-		if(responseBody instanceof Object && responseBody.state != undefined) {
+		if(isNaN(parseInt(responseBody))) {
+			responseBody = eval("(" + responseBody + ")");
 			responseBody = responseBody.state;
 		}
 		var binaryState = parseInt(responseBody);


### PR DESCRIPTION
This PR adds support for using a ESP8266 running ESP Easy as http device. The necessary configuration for the accessory is:

`"off_url": "http://<ip>/control?cmd=GPIO,<gpio-id>,0",
"on_url": "http://<ip>/control?cmd=GPIO,<gpio-id>,1",
"status_url": "http://<ip>/control?cmd=status,GPIO,<gpio-id>",`

The return value for a status request is json data where the member state contains the actual state of the switch:
`{
"log": "",
"plugin": 1,
"pin": <gpio-id>,
"mode": "output",
"state": 0
}
`