### PR TITLE
Expand the abilities of status_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Specify the `brightnesslvl_url` to return the current brightness level as an int
 
 Switch Handling and brightness Handling support 3 methods, yes for polling on app load, realtime for constant polling or no polling
 
-Specify `status_regex` to specify a regular expression to match against in the response to the status_url request to determine if the status is true.  For instance, if your status_url returns "PowerState:true" when the status is on and "PowerState:true" when the status is off, in your configuration you could specify: `"status_regex": "PowerState:true"` 
+Specify `status_regex` to specify a regular expression to match against in the response to the status_url request to determine if the status is true.  For instance, if your status_url returns "PowerState:true" when the status is on and "PowerState:false" when the status is off, in your configuration you could specify: `"status_regex": "PowerState:true"` 
 
 Configuration sample:
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Specify the `brightnesslvl_url` to return the current brightness level as an int
 
 Switch Handling and brightness Handling support 3 methods, yes for polling on app load, realtime for constant polling or no polling
 
+Specify `status_regex` to specify a regular expression to match against in the response to the status_url request to determine if the status is true.  For instance, if your status_url returns "PowerState:true" when the status is on and "PowerState:true" when the status is off, in your configuration you could specify: `"status_regex": "PowerState:true"` 
+
 Configuration sample:
 
  ```

--- a/index.js
+++ b/index.js
@@ -56,8 +56,8 @@ var pollingtoevent = require('polling-to-event');
                 that.state = re.test(data);
             }
             else {
-        	    var binaryState = parseInt(data);
-	    	    that.state = binaryState > 0;
+                var binaryState = parseInt(data);
+                that.state = binaryState > 0;
             }
             that.log(that.service, "received power",that.status_url, "state is currently", that.state.toString());
 			// switch used to easily add additonal services
@@ -178,8 +178,8 @@ var pollingtoevent = require('polling-to-event');
         }
         else
         {
-		    var binaryState = parseInt(responseBody);
-		    powerOn = binaryState > 0;
+            var binaryState = parseInt(responseBody);
+            powerOn = binaryState > 0;
         }
         this.log("Power state is currently %s", powerOn.toString());
 		callback(null, powerOn);


### PR DESCRIPTION
These changes add the ability to use status urls that don't just return a boolean in response to the http request.
To do this it adds support for a new configuration setting: status_regex

If status_regex is missing or empty, the status request code will work the same way that it has previously.

However, if status_regex contains a string, that will be used as a regular expression to test against the response body from the status http request.  If that regular expression matches, then the status will be reported as true.  If the regular expression does not match, then the status will be reported as false.

With this change, the status_url can be easily integrated into a much wider range of devices that return their status in different unique ways.