### PR TITLE
Patch 1.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,20 +175,18 @@ var pollingtoevent = require('polling-to-event');
 		this.log('HTTP get power function failed: %s', error.message);
 		callback(error);
 	} else {
-		var binaryState = parseInt(responseBody.replace(/\D/g,"")); 
-		if (isNaN(binaryState)) { 					//Check if we have a number response
-			var customStatusOn = this.status_on; 
-    			var customStatusOff = this.status_off;
-    			var statusActive = responseBody.includes(customStatusOn);
-    			binaryState = Number(statusActive);
-    			if (isNaN(binaryState)) {				//Check if we have a number now
-    				statusActive = responseBody.includes(customStatusOff);
-        			if (statusActive) binaryState = 0;
-    			}   
-		}
-		var powerOn = binaryState > 0;
-		this.log("Power state is currently %s", binaryState);
-		callback(null, powerOn);
+                var binaryState = parseInt(responseBody.replace(/\D/g,""));
+                if (isNaN(binaryState)) {                                       //Check if we have a number response
+                        var customStatusOn = this.status_on;
+                        var customStatusOff = this.status_off;
+                        var statusOn = responseBody.includes(customStatusOn);
+                        var statusOff = responseBody.includes(customStatusOff);        
+                        if (statusOn) binaryState = 1;
+                        if (statusOff) binaryState = 0;
+                }
+                var powerOn = binaryState > 0;
+                this.log("Power state is currently %s", binaryState);
+                callback(null, powerOn);
 	}
 	}.bind(this));
   },

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ var pollingtoevent = require('polling-to-event');
 		this.off_url                = config["off_url"];
 		this.off_body               = config["off_body"];
 		this.status_url             = config["status_url"];
+		this.status_on 		    = config["status_on"];
+		this.status_off 	    = config["status_off"];
 		this.brightness_url         = config["brightness_url"];
 		this.brightnesslvl_url      = config["brightnesslvl_url"];
 		this.http_method            = config["http_method"] 	  	 	|| "GET";;
@@ -173,15 +175,20 @@ var pollingtoevent = require('polling-to-event');
 		this.log('HTTP get power function failed: %s', error.message);
 		callback(error);
 	} else {
-               if (responseBody.includes("ACTIVE")) {
-                        var isMotionActive = responseBody.includes("ACTIVE");   // Added support for motion http response for ON
-                        var binaryState = Number(isMotionActive);
-                } else {
-                        var binaryState = parseInt(responseBody.replace(/\D/g,""));
-                }
-		var powerOn = binaryState > 0;
-		this.log("Power state is currently %s", binaryState);
-		callback(null, powerOn);
+		var binaryState = parseInt(responseBody.replace(/\D/g,"")); 
+		if (isNaN(binaryState)) { 					//Check if we have a number response
+			var customStatusOn = this.status_on; 
+    			var customStatusOff = this.status_off;
+    			var statusActive = responseBody.includes(customStatusOn);
+    			binaryState = Number(statusActive);
+    			if (isNaN(binaryState)) {				//Check if we have a nuber now
+    				statusActive = responseBody.includes(customStatusOff);
+        			binaryState = Number(statusActive);
+    			}   
+		}
+	var powerOn = binaryState > 0;
+	this.log("Power state is currently %s", binaryState);
+	callback(null, powerOn);
 	}
 	}.bind(this));
   },

--- a/index.js
+++ b/index.js
@@ -186,9 +186,9 @@ var pollingtoevent = require('polling-to-event');
         			binaryState = Number(statusActive);
     			}   
 		}
-	var powerOn = binaryState > 0;
-	this.log("Power state is currently %s", binaryState);
-	callback(null, powerOn);
+		var powerOn = binaryState > 0;
+		this.log("Power state is currently %s", binaryState);
+		callback(null, powerOn);
 	}
 	}.bind(this));
   },

--- a/index.js
+++ b/index.js
@@ -175,15 +175,19 @@ var pollingtoevent = require('polling-to-event');
 		this.log('HTTP get power function failed: %s', error.message);
 		callback(error);
 	} else {
-                var binaryState = parseInt(responseBody.replace(/\D/g,""));
-                if (isNaN(binaryState)) {                                       //Check if we have a number response
-                        var customStatusOn = this.status_on;
-                        var customStatusOff = this.status_off;
-                        var statusOn = responseBody.includes(customStatusOn);
-                        var statusOff = responseBody.includes(customStatusOff);        
-                        if (statusOn) binaryState = 1;
-                        if (statusOff) binaryState = 0;
-                }
+		var binaryState;
+		if (this.status_on && this.status_off) {	//Check if custom status checks are set
+			var customStatusOn = this.status_on;
+                	var customStatusOff = this.status_off;
+			var statusOn = responseBody.includes(customStatusOn);
+                	var statusOff = responseBody.includes(customStatusOff);
+			if (statusOn || statusOff) {				//check if one of the custum status was true
+                        	if (statusOn) binaryState = 1;
+                        	if (statusOff) binaryState = 0;
+			}
+                } else {
+                        binaryState = parseInt(responseBody.replace(/\D/g,""));
+                } 
                 var powerOn = binaryState > 0;
                 this.log("Power state is currently %s", binaryState);
                 callback(null, powerOn);

--- a/index.js
+++ b/index.js
@@ -181,9 +181,9 @@ var pollingtoevent = require('polling-to-event');
     			var customStatusOff = this.status_off;
     			var statusActive = responseBody.includes(customStatusOn);
     			binaryState = Number(statusActive);
-    			if (isNaN(binaryState)) {				//Check if we have a nuber now
+    			if (isNaN(binaryState)) {				//Check if we have a number now
     				statusActive = responseBody.includes(customStatusOff);
-        			binaryState = Number(statusActive);
+        			if (statusActive) binaryState = 0;
     			}   
 		}
 		var powerOn = binaryState > 0;


### PR DESCRIPTION
Include these in config.json, these work with motion, exchange for what you get from your status url.
        "status_on":   "ACTIVE", 
        "status_off":  "PAUSE",
or leave them blank ("") for default function, or try with 1 and 0

Could someone test the default response please.